### PR TITLE
ACM and MCE uninstall updates to address changes in latest releases

### DIFF
--- a/installer/common/common-functions.bash
+++ b/installer/common/common-functions.bash
@@ -93,7 +93,7 @@ function die_if_not_cluster_admin() {
 
 
 #----------------------------------------
-# COnstants for referencing fixed things
+# Constants for referencing fixed things
 #----------------------------------------
 
 # Various CR kindss. Ech <foo>_kind variables identifies one kiind...

--- a/installer/common/find-mce.bash
+++ b/installer/common/find-mce.bash
@@ -7,7 +7,7 @@
 # Requires common-functions.bash, assumed to be already source'ed in.
 
 #----------------------------------------
-# COnstants for referencing fixed things
+# Constants for referencing fixed things
 #----------------------------------------
 
 # OLMM package names:
@@ -39,7 +39,7 @@ cm_local_cluster_ns="local-cluster"
 hive_ns="hive"
 
 #----------------------------------------------
-# Varibles for referencing configurable things
+# Variables for referencing configurable things
 #----------------------------------------------
 
 # Variables for namespaces and other resources that are configurable. Their values

--- a/installer/common/find-mch.bash
+++ b/installer/common/find-mch.bash
@@ -15,7 +15,7 @@ mch_prod_pkg_name="advanced-cluster-management"
 mch_community_pkg_name="stolostron"
 mch_guess_pkg_name="$mch_prod_pkg_name"
 
-# Various CR kindss. Ech <foo>_kind variables identifies one kiind...
+# Various CR kinds. Ech <foo>_kind variables identifies one kind...
 
 # MCH operator kind:
 mch_kind="multiclusterhubs.operator.open-cluster-management.io"
@@ -34,7 +34,7 @@ mco_kind="multiclusterobservabilities.observability.open-cluster-management.io"
 mco_ns="open-cluster-management-observability"
 
 #----------------------------------------------
-# Varibles for referencing configurable things
+# Variables for referencing configurable things
 #----------------------------------------------
 
 # Variables for namespaces and other resources that are configurable. Their values


### PR DESCRIPTION
As more components get added to ACM and MCE there are more things the uninstall script needs to account for.  Note that this is not the standard uninstall, but a special uninstall that may help when the normal uninstall doesn't work.